### PR TITLE
Fix no-argument exceptions across all message event handlers

### DIFF
--- a/Bottomly.Tests/Slack/EventHandlers/GetCurrentKarmaReasonsHandlerTests.cs
+++ b/Bottomly.Tests/Slack/EventHandlers/GetCurrentKarmaReasonsHandlerTests.cs
@@ -50,13 +50,15 @@ public class GetCurrentKarmaReasonsHandlerTests
         _mockKarmaRepo.Verify(r => r.GetKarmaReasonsAsync("alice"), Times.Once());
     }
 
-    [Fact]
-    public async Task HandleAsync_NoRecipient_CallsCommandWithMessageUser()
+    [Theory]
+    [InlineData("_reasons")]
+    [InlineData("_reasons ")]
+    public async Task HandleAsync_NoRecipient_CallsCommandWithMessageUser(string message)
     {
         _mockKarmaRepo.Setup(r => r.GetKarmaReasonsAsync("U_sender")).ReturnsAsync(
             new KarmaReasonsResult(0, new List<Karma>().AsReadOnly()));
 
-        await _handler.HandleAsync(CreateMessage("_reasons "));
+        await _handler.HandleAsync(CreateMessage(message));
 
         _mockKarmaRepo.Verify(r => r.GetKarmaReasonsAsync("U_sender"), Times.Once());
     }

--- a/Bottomly.Tests/Slack/EventHandlers/GiphyHandlerTests.cs
+++ b/Bottomly.Tests/Slack/EventHandlers/GiphyHandlerTests.cs
@@ -78,6 +78,16 @@ public class GiphyHandlerTests
         _mockBroker.Verify(b => b.SendMessageAsync("No gifs found for \"xyz\"", "C1", null), Times.Once());
     }
 
+    [Theory]
+    [InlineData("_gif")]
+    [InlineData("_gif ")]
+    public async Task HandleAsync_NoArgument_SendsPleaseProvideMessage(string text)
+    {
+        await _handler.HandleAsync(CreateMessage(text));
+
+        _mockBroker.Verify(b => b.SendMessageAsync("Please provide a search term.", "C1", null), Times.Once());
+    }
+
     [Fact]
     public async Task HandleAsync_HelpEvent_SendsHelpMessage()
     {

--- a/Bottomly.Tests/Slack/EventHandlers/ImageSearchHandlerTests.cs
+++ b/Bottomly.Tests/Slack/EventHandlers/ImageSearchHandlerTests.cs
@@ -79,6 +79,16 @@ public class ImageSearchHandlerTests
         _mockBroker.Verify(b => b.SendMessageAsync("No image results found for \"xyz\"", "C1", null), Times.Once());
     }
 
+    [Theory]
+    [InlineData("_gi")]
+    [InlineData("_gi ")]
+    public async Task HandleAsync_NoArgument_SendsPleaseProvideMessage(string text)
+    {
+        await _handler.HandleAsync(CreateMessage(text));
+
+        _mockBroker.Verify(b => b.SendMessageAsync("Please provide a search query.", "C1", null), Times.Once());
+    }
+
     [Fact]
     public async Task HandleAsync_HelpEvent_SendsHelpMessage()
     {

--- a/Bottomly.Tests/Slack/EventHandlers/SearchHandlerTests.cs
+++ b/Bottomly.Tests/Slack/EventHandlers/SearchHandlerTests.cs
@@ -66,6 +66,16 @@ public class SearchHandlerTests
         _mockBroker.Verify(b => b.SendMessageAsync("No results found for \"xyz\"", "C1", null), Times.Once());
     }
 
+    [Theory]
+    [InlineData("_g")]
+    [InlineData("_g ")]
+    public async Task HandleAsync_NoArgument_SendsPleaseProvideMessage(string text)
+    {
+        await _handler.HandleAsync(CreateMessage(text));
+
+        _mockBroker.Verify(b => b.SendMessageAsync("Please provide a search query.", "C1", null), Times.Once());
+    }
+
     [Fact]
     public async Task HandleAsync_HelpEvent_SendsHelpMessage()
     {

--- a/Bottomly.Tests/Slack/EventHandlers/UrbanHandlerTests.cs
+++ b/Bottomly.Tests/Slack/EventHandlers/UrbanHandlerTests.cs
@@ -65,6 +65,16 @@ public class UrbanHandlerTests
         _mockBroker.Verify(b => b.SendMessageAsync("Left as an exercise for the reader.", "C1", "ts1"), Times.Once());
     }
 
+    [Theory]
+    [InlineData("_ud")]
+    [InlineData("_ud ")]
+    public async Task HandleAsync_NoArgument_SendsPleaseProvideMessage(string text)
+    {
+        await _handler.HandleAsync(CreateMessage(text));
+
+        _mockBroker.Verify(b => b.SendMessageAsync("Please provide a search term.", "C1", null), Times.Once());
+    }
+
     [Fact]
     public async Task HandleAsync_HelpEvent_SendsHelpMessage()
     {

--- a/Bottomly.Tests/Slack/EventHandlers/WikipediaHandlerTests.cs
+++ b/Bottomly.Tests/Slack/EventHandlers/WikipediaHandlerTests.cs
@@ -65,6 +65,16 @@ public class WikipediaHandlerTests
         _mockBroker.Verify(b => b.SendMessageAsync("No results found for \"xyz\"", "C1", null), Times.Once());
     }
 
+    [Theory]
+    [InlineData("_wik")]
+    [InlineData("_wik ")]
+    public async Task HandleAsync_NoArgument_SendsPleaseProvideMessage(string text)
+    {
+        await _handler.HandleAsync(CreateMessage(text));
+
+        _mockBroker.Verify(b => b.SendMessageAsync("Please provide a search term.", "C1", null), Times.Once());
+    }
+
     [Fact]
     public async Task HandleAsync_HelpEvent_SendsHelpMessage()
     {

--- a/Bottomly/Slack/MessageEventHandlers/GetCurrentKarmaReasonsHandler.cs
+++ b/Bottomly/Slack/MessageEventHandlers/GetCurrentKarmaReasonsHandler.cs
@@ -27,7 +27,7 @@ public class GetCurrentKarmaReasonsHandler(
     protected override async Task InvokeHandlerLogicAsync(MessageEvent message)
     {
         var text = await parser.ReplaceSlackIdTokensWithUsernamesAsync(message.Text!);
-        var recipient = text[CommandTrigger.Length..].Split(' ')[0];
+        var recipient = text[CommandTrigger.TrimEnd().Length..].TrimStart().Split(' ')[0];
         if (string.IsNullOrEmpty(recipient))
         {
             recipient = message.User;

--- a/Bottomly/Slack/MessageEventHandlers/GiphyHandler.cs
+++ b/Bottomly/Slack/MessageEventHandlers/GiphyHandler.cs
@@ -21,7 +21,13 @@ public class GiphyHandler(
 
     protected override async Task InvokeHandlerLogicAsync(MessageEvent message)
     {
-        var term = message.Text![CommandTrigger.Length..];
+        var term = message.Text![CommandTrigger.TrimEnd().Length..].Trim();
+        if (string.IsNullOrEmpty(term))
+        {
+            await SendMessageResponseAsync("Please provide a search term.", message);
+            return;
+        }
+
         var result = await command.ExecuteAsync(term);
 
         if (result is GiphySuccessResult success)

--- a/Bottomly/Slack/MessageEventHandlers/ImageSearchHandler.cs
+++ b/Bottomly/Slack/MessageEventHandlers/ImageSearchHandler.cs
@@ -23,7 +23,13 @@ public class ImageSearchHandler(
 
     protected override async Task InvokeHandlerLogicAsync(MessageEvent message)
     {
-        var query = message.Text![CommandTrigger.Length..];
+        var query = message.Text![CommandTrigger.TrimEnd().Length..].Trim();
+        if (string.IsNullOrEmpty(query))
+        {
+            await SendMessageResponseAsync("Please provide a search query.", message);
+            return;
+        }
+
         var result = await command.ExecuteAsync(query);
 
         if (result is SearchResult success)

--- a/Bottomly/Slack/MessageEventHandlers/SearchHandler.cs
+++ b/Bottomly/Slack/MessageEventHandlers/SearchHandler.cs
@@ -22,7 +22,13 @@ public class SearchHandler(
 
     protected override async Task InvokeHandlerLogicAsync(MessageEvent message)
     {
-        var query = message.Text![CommandTrigger.Length..];
+        var query = message.Text![CommandTrigger.TrimEnd().Length..].Trim();
+        if (string.IsNullOrEmpty(query))
+        {
+            await SendMessageResponseAsync("Please provide a search query.", message);
+            return;
+        }
+
         var result = await command.ExecuteAsync(query);
 
         var response = result switch

--- a/Bottomly/Slack/MessageEventHandlers/UrbanHandler.cs
+++ b/Bottomly/Slack/MessageEventHandlers/UrbanHandler.cs
@@ -20,7 +20,13 @@ public class UrbanHandler(
 
     protected override async Task InvokeHandlerLogicAsync(MessageEvent message)
     {
-        var term = message.Text![CommandTrigger.Length..];
+        var term = message.Text![CommandTrigger.TrimEnd().Length..].Trim();
+        if (string.IsNullOrEmpty(term))
+        {
+            await SendMessageResponseAsync("Please provide a search term.", message);
+            return;
+        }
+
         var result = await command.ExecuteAsync(term);
         var response = result switch
         {

--- a/Bottomly/Slack/MessageEventHandlers/WikipediaHandler.cs
+++ b/Bottomly/Slack/MessageEventHandlers/WikipediaHandler.cs
@@ -20,7 +20,13 @@ public class WikipediaHandler(
 
     protected override async Task InvokeHandlerLogicAsync(MessageEvent message)
     {
-        var term = message.Text![CommandTrigger.Length..];
+        var term = message.Text![CommandTrigger.TrimEnd().Length..].Trim();
+        if (string.IsNullOrEmpty(term))
+        {
+            await SendMessageResponseAsync("Please provide a search term.", message);
+            return;
+        }
+
         var result = await command.ExecuteAsync(term);
         var response = result switch
         {


### PR DESCRIPTION
- GetCurrentKarmaReasonsHandler: fix slice to use TrimEnd().Length so
  '_reasons' (no trailing space) no longer throws; TrimStart() the result
  before splitting so '_reasons alice' still works correctly
- SearchHandler, WikipediaHandler, UrbanHandler, GiphyHandler,
  ImageSearchHandler: same slice fix plus an explicit empty-arg guard
  that sends a user-friendly 'Please provide a...' message instead of
  silently swallowing an ArgumentOutOfRangeException
- Tests: promote GetCurrentKarmaReasonsHandler no-recipient test to
  [Theory] covering both '_reasons' and '_reasons '; add equivalent
  [Theory] no-argument tests to all five mandatory-argument handler
  test classes
